### PR TITLE
Add support for ag grid 27.3.0 blank/notblank filter options

### DIFF
--- a/src/AgGrid.InfiniteRowModel/GetRowsParams.cs
+++ b/src/AgGrid.InfiniteRowModel/GetRowsParams.cs
@@ -81,6 +81,9 @@ namespace AgGrid.InfiniteRowModel
 
         public const string Null = "null";
         public const string NotNull = "notNull";
+
+        public const string Blank = "blank";
+        public const string NotBlank = "notBlank";
     }
 
     public static class FilterModelOperator

--- a/src/AgGrid.InfiniteRowModel/InfiniteScroll.cs
+++ b/src/AgGrid.InfiniteRowModel/InfiniteScroll.cs
@@ -106,7 +106,7 @@ namespace AgGrid.InfiniteRowModel
         {
             return filterModel switch
             {
-                { Type: FilterModelType.Null or FilterModelType.NotNull } => Array.Empty<object>(),
+                { Type: FilterModelType.Null or FilterModelType.NotNull or FilterModelType.Blank or FilterModelType.NotBlank } => Array.Empty<object>(),
 
                 { FilterType: FilterModelFilterType.Text } when options.CaseInsensitive => new object[] { GetString(filterModel.Filter).ToLower() },
                 { FilterType: FilterModelFilterType.Text } => new object[] { GetString(filterModel.Filter) },
@@ -172,8 +172,8 @@ namespace AgGrid.InfiniteRowModel
 
                 { Type: FilterModelType.InRange } => $"{propertyName} >= @{index} AND {propertyName} <= @{index + 1}",
 
-                { Type: FilterModelType.Null } => $"{propertyName} == null",
-                { Type: FilterModelType.NotNull } => $"{propertyName} != null",
+                { Type: FilterModelType.Null or FilterModelType.Blank } => $"{propertyName} == null",
+                { Type: FilterModelType.NotNull or FilterModelType.NotBlank } => $"{propertyName} != null",
 
                 { FilterType: FilterModelFilterType.Set } when options.CaseInsensitive => $"@{index}.Contains({propertyName}.ToLower())",
                 { FilterType: FilterModelFilterType.Set } => $"@{index}.Contains({propertyName})",

--- a/tests/AgGrid.InfiniteRowModel.Tests/Filtering.cs
+++ b/tests/AgGrid.InfiniteRowModel.Tests/Filtering.cs
@@ -347,8 +347,10 @@ namespace AgGrid.InfiniteRowModel.Tests
             Assert.True(result.RowsThisBlock.All(r => expectedIds.Contains(r.Id)));
         }
 
-        [Fact]
-        public void FilterByNull()
+        [Theory]
+        [InlineData(FilterModelType.Null)]
+        [InlineData(FilterModelType.Blank)]
+        public void FilterByNull(string filterModelType)
         {
             var users = new[]
             {
@@ -367,7 +369,7 @@ namespace AgGrid.InfiniteRowModel.Tests
                 EndRow = 10,
                 FilterModel = new Dictionary<string, FilterModel>
                 {
-                    { "fullName", new FilterModel { Type = FilterModelType.Null, FilterType = FilterModelFilterType.Text } }
+                    { "fullName", new FilterModel { Type = filterModelType, FilterType = FilterModelFilterType.Text } }
                 }
             };
 
@@ -480,8 +482,10 @@ namespace AgGrid.InfiniteRowModel.Tests
             Assert.True(result.RowsThisBlock.All(r => expectedIds.Contains(r.Id)));
         }
 
-        [Fact]
-        public void FilterByNotNull()
+        [Theory]
+        [InlineData(FilterModelType.NotNull)]
+        [InlineData(FilterModelType.NotBlank)]
+        public void FilterByNotNull(string filterModelType)
         {
             var users = new[]
             {
@@ -500,7 +504,7 @@ namespace AgGrid.InfiniteRowModel.Tests
                 EndRow = 10,
                 FilterModel = new Dictionary<string, FilterModel>
                 {
-                    { "fullName", new FilterModel { Type = FilterModelType.NotNull, FilterType = FilterModelFilterType.Text } }
+                    { "fullName", new FilterModel { Type = filterModelType, FilterType = FilterModelFilterType.Text } }
                 }
             };
 


### PR DESCRIPTION
Add support for blank/notBlank filter options present in ag-grid v27.3.0

Merges behaviour with existing not/notnull options